### PR TITLE
Access Token 응답에 expires_in 파라미터가 있으면 쿠키에 Expires 속성 설정

### DIFF
--- a/wsgioauth2.py
+++ b/wsgioauth2.py
@@ -355,14 +355,13 @@ class WSGIMiddleware(object):
                 sig = hmac.new(self.secret, session, hashlib.sha1).hexdigest()
                 signed_session = '{0},{1}'.format(sig, session)
                 signed_session = base64.urlsafe_b64encode(signed_session)
-                set_cookie = '{0}="{1}"; Path=/'.format(self.cookie,
-                                                        signed_session)
+                set_cookie = Cookie.SimpleCookie()
+                set_cookie[self.cookie] = signed_session
+                set_cookie[self.cookie]['path'] = '/'
                 if 'expires_in' in access_token:
                     expires_in = int(access_token['expires_in'])
-                    from datetime import datetime, timedelta
-                    expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
-                    expires = expires_at.strftime('%a, %d %b %Y %T GMT')
-                    set_cookie += '; Expires={0}'.format(expires)
+                    set_cookie[self.cookie]['expires'] = expires_in
+                set_cookie = set_cookie[self.cookie].OutputString()
                 return self.redirect(query_dict.get('state', [''])[0],
                                      start_response,
                                      headers={'Set-Cookie': set_cookie})


### PR DESCRIPTION
- 응용 프로그램은 Access Token 응답을 수신한 시점을 정확히 알 수 없기 때문에, environ['wsgioauth2.session']['expires_in'] 값을 참조하는 것만으로는 이 토큰이 정확히 언제 만료되는 것인지 알기 어려움.
- 따라서 WSGIMiddleware가 Access Token을 수신하여 쿠키에 저장하는 시점에 만료 시점도 함께 설정.
- 쿠키 헤더를 직접 포매팅하는 대신 Cookie.SimpleCookie를 이용하여 포맷
