### PR TITLE
Fix request_access_token to understand content-type with charsets

### DIFF
--- a/wsgioauth2.py
+++ b/wsgioauth2.py
@@ -283,7 +283,7 @@ class Client(object):
                 'grant_type': 'authorization_code'}
         u = urllib2.urlopen(self.service.access_token_endpoint,
                             data=urllib.urlencode(form))
-        content_type = u.info().get('Content-Type')
+        content_type = u.info().gettype()
         if content_type == 'application/json':
             data = json.load(u)
         else:


### PR DESCRIPTION
Prior to the change, request_access_token would fail again token endpoints that returned content-types of the form "application/json;charset=utf8".
