### PR TITLE
Make it possible to protect only parts of an app.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -126,6 +126,13 @@ The package is written by `Hong Minhee`_ for StyleShare_.
 Changelog
 ---------
 
+Version 0.1.4
+'''''''''''''
+
+- :attr:`~wsgioauth2.WSGIMiddleware.login_path` can now be configured to
+  protect only a subsection of an application.
+  [:pull:`8` by Aymeric Augustin]
+
 Version 0.1.3
 '''''''''''''
 


### PR DESCRIPTION
Here's my use case for Django's Trac.

Anyone including GoogleBot should be allowed to browse Trac without having to authenticate.

When a user authenticates, Trac expects REMOTE_USER to be set on a request to /login. Then it creates its own session and doesn't neet REMOTE_USER anymore. Finally on /logout it destroys its session.

For this reason I want OAuth2 to be triggered only on /login, and only on /login. This pull requests make it possible.
