### PR TITLE
Support users who didn't declare their name on GitHub.

### DIFF
--- a/wsgioauth2.py
+++ b/wsgioauth2.py
@@ -190,7 +190,7 @@ class GitHubService(Service):
         response = json.loads(response)
         # Copy useful data
         access_token["username"] = response["login"]
-        access_token["name"] = response["name"]
+        access_token["name"] = response.get("name", "")
 
     def is_user_allowed(self, access_token):
         """Check if the authenticated user is allowed to access the protected


### PR DESCRIPTION
A user couldn't log in and the logs contained the following stack trace:

```
Traceback (most recent call last):
  File "/path/to/venv/lib/python2.6/site-packages/wsgioauth2.py", line 542, in __call__
    self.client.load_username(access_token)
  File "/path/to/venv/lib/python2.6/site-packages/wsgioauth2.py", line 262, in load_username
    self.service.load_username(access_token)
  File "/path/to/venv/lib/python2.6/site-packages/wsgioauth2.py", line 158, in load_username
    access_token["name"] = response["name"]
KeyError: 'name'
```

It seems that GitHub omits the 'name' attribute in the user JSON when the user doesn't declare their name, which is optional when creating an account.
